### PR TITLE
fix: fallback value for HTTP_USER_AGENT should be a string

### DIFF
--- a/private_storage/views.py
+++ b/private_storage/views.py
@@ -122,7 +122,7 @@ class PrivateStorageView(View):
         The filename, encoded to use in a ``Content-Disposition`` header.
         """
         # Based on https://www.djangosnippets.org/snippets/1710/
-        user_agent = self.request.META.get('HTTP_USER_AGENT', None)
+        user_agent = self.request.META.get('HTTP_USER_AGENT', '')
         if 'WebKit' in user_agent:
             # Support available for UTF-8 encoded strings.
             # This also matches Edgee.


### PR DESCRIPTION
if `request.META["HTTP_USER_AGENT"]` is not set the fallback value should an empty string instead of None
or else we get a `TypeError: argument of type 'NoneType' is not iterable` on `if 'WebKit' in user_agent:`